### PR TITLE
Modified to use associated type for Address instead of generic

### DIFF
--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronized, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronized, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronized, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronized, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/emulator-hal-memory/src/lib.rs
+++ b/emulator-hal-memory/src/lib.rs
@@ -75,10 +75,11 @@ where
     */
 }
 
-impl<Address, Instant> BusAccess<Address, Instant> for MemoryBlock<Address, Instant>
+impl<Address, Instant> BusAccess<Instant> for MemoryBlock<Address, Instant>
 where
     Address: TryInto<usize> + Copy,
 {
+    type Address = Address;
     type Error = SimpleBusError;
 
     fn read(


### PR DESCRIPTION
This switches to using an associated type for the `Address` of a `BusAccess`.  It doesn't end up changing much.  A real-world example is needed to compare the pros and cons.