### PR TITLE
Add auto adapter

### DIFF
--- a/emulator-hal-memory/src/lib.rs
+++ b/emulator-hal-memory/src/lib.rs
@@ -55,7 +55,7 @@ impl<Instant> MemoryBlock<Instant> {
     /// The `MemoryBlock` must already be big enough to contain the contents of the file
     pub fn load_at(&mut self, addr: usize, filename: &str) -> Result<(), io::Error> {
         let contents = std::fs::read(filename)?;
-        self.contents[(addr as usize)..(addr as usize) + contents.len()].copy_from_slice(&contents);
+        self.contents[addr..addr + contents.len()].copy_from_slice(&contents);
         Ok(())
     }
 }
@@ -77,6 +77,11 @@ where
         let addr = addr
             .try_into()
             .map_err(|_| BasicBusError::UnmappedAddress)?;
+
+        if addr + data.len() > self.contents.len() {
+            return Err(BasicBusError::UnmappedAddress);
+        }
+
         data.copy_from_slice(&self.contents[addr..addr + data.len()]);
         Ok(data.len())
     }
@@ -89,6 +94,11 @@ where
         let addr = addr
             .try_into()
             .map_err(|_| BasicBusError::UnmappedAddress)?;
+
+        if addr + data.len() > self.contents.len() {
+            return Err(BasicBusError::UnmappedAddress);
+        }
+
         self.contents[addr..addr + data.len()].copy_from_slice(data);
         Ok(data.len())
     }

--- a/emulator-hal-memory/src/lib.rs
+++ b/emulator-hal-memory/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use emulator_hal::{BusAccess, Instant as EmuInstant, BasicBusError};
+use emulator_hal::{BasicBusError, BusAccess, Instant as EmuInstant};
 
 /// A contiguous block of memory, backed by a `Vec`
 pub struct MemoryBlock<Instant> {

--- a/emulator-hal-memory/src/lib.rs
+++ b/emulator-hal-memory/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use emulator_hal::{BusAccess, SimpleBusError, Instant as EmuInstant};
+use emulator_hal::{BusAccess, Instant as EmuInstant, SimpleBusError};
 
 /// A contiguous block of memory, backed by a `Vec`
 pub struct MemoryBlock<Address, Instant>

--- a/emulator-hal-memory/src/lib.rs
+++ b/emulator-hal-memory/src/lib.rs
@@ -7,8 +7,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use emulator_hal::bus::{BusAccess, SimpleBusError};
-use emulator_hal::time;
+use emulator_hal::{BusAccess, SimpleBusError, Instant as EmuInstant};
 
 /// A contiguous block of memory, backed by a `Vec`
 pub struct MemoryBlock<Address, Instant>
@@ -79,7 +78,7 @@ where
 impl<Address, Instant> BusAccess<Address> for MemoryBlock<Address, Instant>
 where
     Address: TryInto<usize> + Copy,
-    Instant: time::Instant,
+    Instant: EmuInstant,
 {
     type Instant = Instant;
     type Error = SimpleBusError;
@@ -114,7 +113,7 @@ where
 mod tests {
     use super::*;
     use alloc::vec;
-    use emulator_hal::time::Instant;
+    use emulator_hal::Instant;
     use std::time::Duration;
 
     #[test]

--- a/emulator-hal/Cargo.toml
+++ b/emulator-hal/Cargo.toml
@@ -18,3 +18,5 @@ femtos = { version = "0.1", optional = true }
 default = ["alloc"]
 alloc = []
 std = []
+fugit = ["dep:fugit"]
+femtos = ["dep:femtos"]

--- a/emulator-hal/src/adapter.rs
+++ b/emulator-hal/src/adapter.rs
@@ -171,6 +171,13 @@ where
 #[derive(Copy, Clone, Debug, Default)]
 pub struct NoBus<Instant>(PhantomData<Instant>);
 
+impl<Instant> NoBus<Instant> {
+    /// Returns a new dummy bus
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<Address, Instant> BusAccess<Address> for NoBus<Instant>
 where
     Address: Copy,

--- a/emulator-hal/src/adapter.rs
+++ b/emulator-hal/src/adapter.rs
@@ -1,0 +1,107 @@
+//! Bus Adapters to translate address and error type
+
+use crate::{BusAccess, Error};
+
+/// Used to translate an address from one address space into another
+pub trait FromAddress<T> {
+    /// Translate the given address into an address of type `Self`
+    fn from_address(address: T) -> Self;
+}
+
+/// Used to translate an address from one address space into another
+pub trait IntoAddress<T> {
+    /// Translate the given address into an address of type `T`
+    fn into_address(self) -> T;
+}
+
+impl<T, S> IntoAddress<T> for S
+where
+    T: FromAddress<S>,
+{
+    fn into_address(self) -> T {
+        T::from_address(self)
+    }
+}
+
+/// An adapter that applies an address translation before accessing a wrapped bus object
+///
+/// This object implements the `BusAccess` trait, and takes address of type `AddressIn`,
+/// applies the provided address translation function to produce an address of type `AddressOut`,
+/// and then calls the equivalent trait method with that produced address, return the result
+pub struct BusAdapter<AddressIn, AddressOut, Bus, ErrorOut>
+where
+    AddressIn: Copy,
+    AddressOut: Copy,
+    Bus: BusAccess<AddressOut>,
+{
+    /// The underlying object implementing `BusAccess` that this object adapts
+    pub inner: Bus,
+    /// The translation function applied
+    pub translate: fn(AddressIn) -> AddressOut,
+    /// The error mapping function applied
+    pub map_err: fn(Bus::Error) -> ErrorOut,
+}
+
+impl<AddressIn, AddressOut, Bus, ErrorOut> BusAdapter<AddressIn, AddressOut, Bus, ErrorOut>
+where
+    AddressIn: Copy,
+    AddressOut: Copy,
+    Bus: BusAccess<AddressOut>,
+{
+    /// Construct a new instance of an adapter for the given `bus` object
+    pub fn new(
+        inner: Bus,
+        translate: fn(AddressIn) -> AddressOut,
+        map_err: fn(Bus::Error) -> ErrorOut,
+    ) -> Self {
+        Self {
+            inner,
+            translate,
+            map_err,
+        }
+    }
+}
+
+impl<AddressIn, AddressOut, Bus, ErrorOut> BusAccess<AddressIn>
+    for BusAdapter<AddressIn, AddressOut, Bus, ErrorOut>
+where
+    AddressIn: Copy,
+    AddressOut: Copy,
+    Bus: BusAccess<AddressOut>,
+    ErrorOut: Error,
+{
+    type Instant = Bus::Instant;
+    type Error = ErrorOut;
+
+    #[inline]
+    fn read(
+        &mut self,
+        now: Self::Instant,
+        addr: AddressIn,
+        data: &mut [u8],
+    ) -> Result<usize, Self::Error> {
+        let addr = (self.translate)(addr);
+        self.inner.read(now, addr, data).map_err(self.map_err)
+    }
+
+    #[inline]
+    fn write(
+        &mut self,
+        now: Self::Instant,
+        addr: AddressIn,
+        data: &[u8],
+    ) -> Result<usize, Self::Error> {
+        let addr = (self.translate)(addr);
+        self.inner.write(now, addr, data).map_err(self.map_err)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_implemeting_memory() {
+        // TODO write tests
+    }
+}

--- a/emulator-hal/src/adapter.rs
+++ b/emulator-hal/src/adapter.rs
@@ -1,6 +1,6 @@
 //! Bus Adapters to translate address and error type
 
-use crate::{BasicBusError, BusAccess, Error, Instant as EmuInstant};
+use crate::{BasicBusError, BusAccess, ErrorType, Instant as EmuInstant};
 use core::marker::PhantomData;
 
 /// Used to translate an address from one address space into another
@@ -67,7 +67,7 @@ where
     AddressIn: Copy,
     AddressOut: Copy,
     Bus: BusAccess<AddressOut>,
-    ErrorOut: Error + From<Bus::Error>,
+    ErrorOut: ErrorType + From<Bus::Error>,
 {
     type Instant = Bus::Instant;
     type Error = ErrorOut;
@@ -137,7 +137,7 @@ where
     AddressIn: Copy,
     AddressOut: FromAddress<AddressIn> + Copy,
     Bus: BusAccess<AddressOut>,
-    ErrorOut: Error + From<Bus::Error>,
+    ErrorOut: ErrorType + From<Bus::Error>,
 {
     type Instant = Bus::Instant;
     type Error = ErrorOut;
@@ -210,12 +210,13 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::ErrorType;
     use std::time::Duration;
 
     #[derive(Clone, Debug)]
     enum Error {}
 
-    impl super::Error for Error {}
+    impl ErrorType for Error {}
 
     struct Memory(Vec<u8>);
 
@@ -253,7 +254,7 @@ mod test {
         BusError,
     }
 
-    impl super::Error for Error2 {}
+    impl ErrorType for Error2 {}
 
     impl From<Error> for Error2 {
         fn from(_err: Error) -> Self {

--- a/emulator-hal/src/adapter.rs
+++ b/emulator-hal/src/adapter.rs
@@ -1,6 +1,7 @@
 //! Bus Adapters to translate address and error type
 
 use crate::{BusAccess, Error};
+use core::marker::PhantomData;
 
 /// Used to translate an address from one address space into another
 pub trait FromAddress<T> {
@@ -33,13 +34,14 @@ where
     AddressIn: Copy,
     AddressOut: Copy,
     Bus: BusAccess<AddressOut>,
+    ErrorOut: From<Bus::Error>,
 {
     /// The underlying object implementing `BusAccess` that this object adapts
     pub inner: Bus,
     /// The translation function applied
     pub translate: fn(AddressIn) -> AddressOut,
-    /// The error mapping function applied
-    pub map_err: fn(Bus::Error) -> ErrorOut,
+    /// Marker for the error type
+    error_out: PhantomData<ErrorOut>,
 }
 
 impl<AddressIn, AddressOut, Bus, ErrorOut> BusAdapter<AddressIn, AddressOut, Bus, ErrorOut>
@@ -47,17 +49,14 @@ where
     AddressIn: Copy,
     AddressOut: Copy,
     Bus: BusAccess<AddressOut>,
+    ErrorOut: From<Bus::Error>,
 {
     /// Construct a new instance of an adapter for the given `bus` object
-    pub fn new(
-        inner: Bus,
-        translate: fn(AddressIn) -> AddressOut,
-        map_err: fn(Bus::Error) -> ErrorOut,
-    ) -> Self {
+    pub fn new(inner: Bus, translate: fn(AddressIn) -> AddressOut) -> Self {
         Self {
             inner,
             translate,
-            map_err,
+            error_out: PhantomData,
         }
     }
 }
@@ -68,7 +67,7 @@ where
     AddressIn: Copy,
     AddressOut: Copy,
     Bus: BusAccess<AddressOut>,
-    ErrorOut: Error,
+    ErrorOut: Error + From<Bus::Error>,
 {
     type Instant = Bus::Instant;
     type Error = ErrorOut;
@@ -81,7 +80,7 @@ where
         data: &mut [u8],
     ) -> Result<usize, Self::Error> {
         let addr = (self.translate)(addr);
-        self.inner.read(now, addr, data).map_err(self.map_err)
+        self.inner.read(now, addr, data).map_err(|err| err.into())
     }
 
     #[inline]
@@ -92,16 +91,187 @@ where
         data: &[u8],
     ) -> Result<usize, Self::Error> {
         let addr = (self.translate)(addr);
-        self.inner.write(now, addr, data).map_err(self.map_err)
+        self.inner.write(now, addr, data).map_err(|err| err.into())
+    }
+}
+
+/// An adapter that uses the `FromAddress` trait to translate an address before accessing a wrapped bus object
+///
+/// This object implements the `BusAccess` trait, and takes address of type `AddressIn`,
+/// applies `FromAddress<AddressIn>` trait to produce an address of type `AddressOut`,
+/// and then calls the equivalent trait method with that produced address, return the result
+pub struct AutoBusAdapter<AddressIn, AddressOut, Bus, ErrorOut>
+where
+    AddressOut: FromAddress<AddressIn> + Copy,
+    Bus: BusAccess<AddressOut>,
+    ErrorOut: From<Bus::Error>,
+{
+    /// The underlying object implementing `BusAccess` that this object adapts
+    pub inner: Bus,
+
+    address_in: PhantomData<AddressIn>,
+    address_out: PhantomData<AddressOut>,
+    error_out: PhantomData<ErrorOut>,
+}
+
+impl<AddressIn, AddressOut, Bus, ErrorOut> AutoBusAdapter<AddressIn, AddressOut, Bus, ErrorOut>
+where
+    AddressOut: FromAddress<AddressIn> + Copy,
+    Bus: BusAccess<AddressOut>,
+    ErrorOut: From<Bus::Error>,
+{
+    /// Construct a new instance of an adapter for the given `bus` object
+    pub fn new(inner: Bus) -> Self {
+        Self {
+            inner,
+            address_in: PhantomData,
+            address_out: PhantomData,
+            error_out: PhantomData,
+        }
+    }
+}
+
+impl<AddressIn, AddressOut, Bus, ErrorOut> BusAccess<AddressIn>
+    for AutoBusAdapter<AddressIn, AddressOut, Bus, ErrorOut>
+where
+    AddressIn: Copy,
+    AddressOut: FromAddress<AddressIn> + Copy,
+    Bus: BusAccess<AddressOut>,
+    ErrorOut: Error + From<Bus::Error>,
+{
+    type Instant = Bus::Instant;
+    type Error = ErrorOut;
+
+    #[inline]
+    fn read(
+        &mut self,
+        now: Self::Instant,
+        addr: AddressIn,
+        data: &mut [u8],
+    ) -> Result<usize, Self::Error> {
+        let addr = addr.into_address();
+        self.inner.read(now, addr, data).map_err(|err| err.into())
+    }
+
+    #[inline]
+    fn write(
+        &mut self,
+        now: Self::Instant,
+        addr: AddressIn,
+        data: &[u8],
+    ) -> Result<usize, Self::Error> {
+        let addr = addr.into_address();
+        self.inner.write(now, addr, data).map_err(|err| err.into())
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::time::Duration;
+
+    #[derive(Clone, Debug)]
+    enum Error {}
+
+    impl super::Error for Error {}
+
+    struct Memory(Vec<u8>);
+
+    impl BusAccess<u64> for Memory {
+        type Instant = Duration;
+        type Error = Error;
+
+        fn read(
+            &mut self,
+            _now: Duration,
+            addr: u64,
+            data: &mut [u8],
+        ) -> Result<usize, Self::Error> {
+            let addr = addr as usize;
+            data.copy_from_slice(&self.0[addr..addr + data.len()]);
+            Ok(data.len())
+        }
+
+        fn write(&mut self, _now: Duration, addr: u64, data: &[u8]) -> Result<usize, Self::Error> {
+            let addr = addr as usize;
+            self.0[addr..addr + data.len()].copy_from_slice(data);
+            Ok(data.len())
+        }
+    }
+
+    type Address = u8;
+    impl FromAddress<Address> for u64 {
+        fn from_address(address: Address) -> u64 {
+            address as u64
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    enum Error2 {
+        BusError,
+    }
+
+    impl super::Error for Error2 {}
+
+    impl From<Error> for Error2 {
+        fn from(_err: Error) -> Self {
+            Error2::BusError
+        }
+    }
 
     #[test]
-    fn test_implemeting_memory() {
-        // TODO write tests
+    fn test_adapt_address() {
+        let bus = Memory(vec![0; 1024]);
+
+        let mut adapter = BusAdapter::new(bus, |addr| addr as u64);
+
+        let expected_value = 0x1234;
+        adapter
+            .write_beu16(Duration::ZERO, 0, expected_value)
+            .unwrap();
+        let result: Result<u16, Error> = adapter.read_beu16(Duration::ZERO, 0);
+        assert_eq!(result.unwrap(), expected_value);
+    }
+
+    #[test]
+    fn test_adapt_error() {
+        let bus = Memory(vec![0; 1024]);
+
+        let mut adapter = BusAdapter::new(bus, |addr| addr as u64);
+
+        let expected_value = 0x1234;
+        adapter
+            .write_beu16(Duration::ZERO, 0, expected_value)
+            .unwrap();
+        let result: Result<u16, Error2> = adapter.read_beu16(Duration::ZERO, 0);
+        assert_eq!(result.unwrap(), expected_value);
+    }
+
+    #[test]
+    fn test_auto_adapt_address() {
+        let bus = Memory(vec![0; 1024]);
+
+        let mut adapter = AutoBusAdapter::new(bus);
+
+        let expected_value = 0x1234;
+        adapter
+            .write_beu16(Duration::ZERO, 0, expected_value)
+            .unwrap();
+        let result: Result<u16, Error> = adapter.read_beu16(Duration::ZERO, 0);
+        assert_eq!(result.unwrap(), expected_value);
+    }
+
+    #[test]
+    fn test_auto_adapt_error() {
+        let bus = Memory(vec![0; 1024]);
+
+        let mut adapter = AutoBusAdapter::new(bus);
+
+        let expected_value = 0x1234;
+        adapter
+            .write_beu16(Duration::ZERO, 0, expected_value)
+            .unwrap();
+        let result: Result<u16, Error2> = adapter.read_beu16(Duration::ZERO, 0);
+        assert_eq!(result.unwrap(), expected_value);
     }
 }

--- a/emulator-hal/src/adapter.rs
+++ b/emulator-hal/src/adapter.rs
@@ -1,6 +1,6 @@
 //! Bus Adapters to translate address and error type
 
-use crate::{BusAccess, Error};
+use crate::{BasicBusError, BusAccess, Error, Instant as EmuInstant};
 use core::marker::PhantomData;
 
 /// Used to translate an address from one address space into another
@@ -162,6 +162,41 @@ where
     ) -> Result<usize, Self::Error> {
         let addr = addr.into_address();
         self.inner.write(now, addr, data).map_err(|err| err.into())
+    }
+}
+
+/// A dummy object that implements BusAccess, but does nothing
+///
+/// This object can be used instead of `Option<Bus>` when an optional bus is not provided
+#[derive(Copy, Clone, Debug, Default)]
+pub struct NoBus<Instant>(PhantomData<Instant>);
+
+impl<Address, Instant> BusAccess<Address> for NoBus<Instant>
+where
+    Address: Copy,
+    Instant: EmuInstant,
+{
+    type Instant = Instant;
+    type Error = BasicBusError;
+
+    #[inline]
+    fn read(
+        &mut self,
+        _now: Self::Instant,
+        _addr: Address,
+        _data: &mut [u8],
+    ) -> Result<usize, Self::Error> {
+        Ok(0)
+    }
+
+    #[inline]
+    fn write(
+        &mut self,
+        _now: Self::Instant,
+        _addr: Address,
+        _data: &[u8],
+    ) -> Result<usize, Self::Error> {
+        Ok(0)
     }
 }
 

--- a/emulator-hal/src/bus.rs
+++ b/emulator-hal/src/bus.rs
@@ -5,9 +5,9 @@ use core::convert::Infallible;
 use core::fmt;
 
 /// Represents an error that occurred during a bus transaction
-pub trait Error: fmt::Debug {}
+pub trait ErrorType: fmt::Debug {}
 
-impl Error for Infallible {}
+impl ErrorType for Infallible {}
 
 /// A simple pre-defined error type for bus transactions
 #[derive(Debug)]
@@ -21,14 +21,14 @@ pub enum BasicBusError {
 
     /// Some other kind of error has occurred
     #[cfg(feature = "alloc")]
-    Other(alloc::boxed::Box<dyn Error>),
+    Other(alloc::boxed::Box<dyn ErrorType>),
 
     /// Some other kind of error has occurred
     #[cfg(not(feature = "alloc"))]
     Other,
 }
 
-impl Error for BasicBusError {}
+impl ErrorType for BasicBusError {}
 
 /// Represents the order of bytes in a `BusAccess` operation
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -53,7 +53,7 @@ where
     type Instant: Instant;
 
     /// The type of an error returned by this bus
-    type Error: Error;
+    type Error: ErrorType;
 
     /// Read an arbitrary length of bytes from this device, at time `now`
     ///
@@ -371,7 +371,7 @@ mod test {
         #[derive(Clone, Debug)]
         enum Error {}
 
-        impl super::Error for Error {}
+        impl ErrorType for Error {}
 
         struct Memory(Vec<u8>);
 

--- a/emulator-hal/src/bus.rs
+++ b/emulator-hal/src/bus.rs
@@ -401,7 +401,7 @@ where
     Bus: BusAccess<AddressOut>,
 {
     /// The underlying object implementing `BusAccess` that this object adapts
-    pub bus: Bus,
+    pub inner: Bus,
     /// The translation function applied
     pub translate: fn(AddressIn) -> AddressOut,
     /// The error mapping function applied
@@ -416,12 +416,12 @@ where
 {
     /// Construct a new instance of an adapter for the given `bus` object
     pub fn new(
-        bus: Bus,
+        inner: Bus,
         translate: fn(AddressIn) -> AddressOut,
         map_err: fn(Bus::Error) -> ErrorOut,
     ) -> Self {
         Self {
-            bus,
+            inner,
             translate,
             map_err,
         }
@@ -447,7 +447,7 @@ where
         data: &mut [u8],
     ) -> Result<usize, Self::Error> {
         let addr = (self.translate)(addr);
-        self.bus.read(now, addr, data).map_err(self.map_err)
+        self.inner.read(now, addr, data).map_err(self.map_err)
     }
 
     #[inline]
@@ -458,7 +458,7 @@ where
         data: &[u8],
     ) -> Result<usize, Self::Error> {
         let addr = (self.translate)(addr);
-        self.bus.write(now, addr, data).map_err(self.map_err)
+        self.inner.write(now, addr, data).map_err(self.map_err)
     }
 }
 

--- a/emulator-hal/src/bus.rs
+++ b/emulator-hal/src/bus.rs
@@ -1,8 +1,8 @@
 //! Traits for emulating read and write bus operations
 
-use core::fmt;
-use core::convert::Infallible;
 use crate::time::Instant;
+use core::convert::Infallible;
+use core::fmt;
 
 /// Used to translate an address from one address space into another
 pub trait FromAddress<T> {

--- a/emulator-hal/src/lib.rs
+++ b/emulator-hal/src/lib.rs
@@ -5,6 +5,9 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+mod adapter;
+pub use crate::adapter::*;
+
 mod bus;
 pub use crate::bus::*;
 

--- a/emulator-hal/src/lib.rs
+++ b/emulator-hal/src/lib.rs
@@ -5,10 +5,14 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-pub mod bus;
+mod bus;
+pub use crate::bus::*;
 
-//pub mod interrupt;
+//mod interrupt;
+//pub use crate::interrupt::*;
 
-pub mod step;
+mod step;
+pub use crate::step::*;
 
-pub mod time;
+mod time;
+pub use crate::time::*;

--- a/emulator-hal/src/step.rs
+++ b/emulator-hal/src/step.rs
@@ -11,7 +11,7 @@ use crate::bus::BusAccess;
 pub trait Step<Address, Bus>
 where
     Address: Copy,
-    Bus: BusAccess<Address>,
+    Bus: BusAccess<Address> + ?Sized,
 {
     /// A type that is return if the step cannot be performed
     ///
@@ -38,7 +38,7 @@ where
 pub trait Inspect<Address, Bus, Writer>
 where
     Address: Copy,
-    Bus: BusAccess<Address>,
+    Bus: BusAccess<Address> + ?Sized,
     Writer: fmt::Write,
 {
     /// A type that describes the types of information or state that this device can emit
@@ -66,7 +66,7 @@ where
 pub trait Debug<Address, Bus, Writer>: Inspect<Address, Bus, Writer> + Step<Address, Bus>
 where
     Address: Copy,
-    Bus: BusAccess<Address>,
+    Bus: BusAccess<Address> + ?Sized,
     Writer: fmt::Write,
 {
     /// Represents an error that can occur while debugging

--- a/emulator-hal/src/step.rs
+++ b/emulator-hal/src/step.rs
@@ -2,8 +2,8 @@
 
 use core::fmt;
 
-use crate::time::Instant;
 use crate::bus::BusAccess;
+use crate::time::Instant;
 
 /// Represents a device that can change state with the passage of a clock signal
 ///
@@ -71,8 +71,8 @@ where
 /// Control the execution of a CPU device for debugging purposes
 pub trait Debug<Address, Bus, Writer>: Inspect<Bus, Writer> + Step<Bus>
 where
-    Address: Copy,
     // TODO without the added BusAccess<Address> constraint, this Address isn't tied to the bus, and it's left to the implementer to add that constraint
+    Address: Copy,
     Bus: ?Sized,
     Writer: fmt::Write,
 {

--- a/emulator-hal/src/step.rs
+++ b/emulator-hal/src/step.rs
@@ -95,7 +95,7 @@ where
 mod test {
     use super::*;
 
-    use crate::{BusAccess, Instant, BusAdapter, BasicBusError, Error as EmuError};
+    use crate::{BasicBusError, BusAccess, BusAdapter, Error as EmuError, Instant};
     use std::ops::Range;
     use std::str;
     use std::time::Duration;
@@ -106,6 +106,12 @@ mod test {
     }
 
     impl EmuError for Error {}
+
+    impl From<BasicBusError> for Error {
+        fn from(_err: BasicBusError) -> Self {
+            Error::BusError
+        }
+    }
 
     struct Memory(Vec<u8>);
 
@@ -137,6 +143,12 @@ mod test {
     }
 
     impl EmuError for OutputError {}
+
+    impl From<OutputError> for Error {
+        fn from(_err: OutputError) -> Self {
+            Error::BusError
+        }
+    }
 
     struct Output();
 
@@ -324,19 +336,11 @@ mod test {
             devices: vec![
                 (
                     0..0x1_0000,
-                    Box::new(BusAdapter::new(
-                        memory,
-                        |addr| addr as u32,
-                        |_| Error::BusError,
-                    )),
+                    Box::new(BusAdapter::new(memory, |addr| addr as u32)),
                 ),
                 (
                     0x2_0000..0x2_0010,
-                    Box::new(BusAdapter::new(
-                        output,
-                        |addr| addr as u16,
-                        |_| Error::BusError,
-                    )),
+                    Box::new(BusAdapter::new(output, |addr| addr as u16)),
                 ),
             ],
         };

--- a/emulator-hal/src/step.rs
+++ b/emulator-hal/src/step.rs
@@ -2,7 +2,6 @@
 
 use core::fmt;
 
-use crate::bus::BusAccess;
 use crate::time::Instant;
 
 /// Represents a device that can change state with the passage of a clock signal
@@ -96,8 +95,7 @@ where
 mod test {
     use super::*;
 
-    use crate::bus::{self, BusAdapter, SimpleBusError};
-    use crate::time::Instant;
+    use crate::{BusAccess, Instant, BusAdapter, BasicBusError, Error as EmuError};
     use std::ops::Range;
     use std::str;
     use std::time::Duration;
@@ -107,13 +105,13 @@ mod test {
         BusError,
     }
 
-    impl bus::Error for Error {}
+    impl EmuError for Error {}
 
     struct Memory(Vec<u8>);
 
     impl BusAccess<u32> for Memory {
         type Instant = Duration;
-        type Error = SimpleBusError;
+        type Error = BasicBusError;
 
         fn read(
             &mut self,
@@ -138,7 +136,7 @@ mod test {
         Utf8Error,
     }
 
-    impl bus::Error for OutputError {}
+    impl EmuError for OutputError {}
 
     struct Output();
 

--- a/emulator-hal/src/time.rs
+++ b/emulator-hal/src/time.rs
@@ -1,15 +1,16 @@
 //! Traits and implementations for coordinating time between emulated components
 
+use core::fmt::Debug;
 use core::ops::{Add, Mul};
 use core::time::Duration;
 
 /// Represents a monotonic instant in time
-pub trait Instant: Add<Self::Duration, Output = Self> + Eq + Ord + Copy {
+pub trait Instant: Add<Self::Duration, Output = Self> + Eq + Ord + Debug + Copy {
     /// The start of the epoch according to this time representation
     const START: Self;
 
     /// Represents a duration that can be added to an instant of this type
-    type Duration: Mul<u32, Output = Self::Duration>;
+    type Duration: Mul<u32, Output = Self::Duration> + Debug;
 
     /// Returns the duration of one period of the given frequency is hertz
     fn hertz_to_duration(hertz: u64) -> Self::Duration;

--- a/emulator-hal/src/time.rs
+++ b/emulator-hal/src/time.rs
@@ -4,7 +4,7 @@ use core::ops::{Add, Mul};
 use core::time::Duration;
 
 /// Represents a monotonic instant in time
-pub trait Instant: Add<Self::Duration, Output = Self> + Copy {
+pub trait Instant: Add<Self::Duration, Output = Self> + Eq + Ord + Copy {
     /// The start of the epoch according to this time representation
     const START: Self;
 


### PR DESCRIPTION
This PR moves `BusAdapter` to its own file, and adds `AutoBusAdapter` which uses `IntoAddress` and `FromAddress` to implement the address translation.  Error mapping has been moved for both to using the `From` trait.  I'm hoping they will make it possible for the compiler to optimize better than with closures, as well as being easier to use since the translation only has to be defined once, but it also takes away some fine-grained control.

It also includes some clean up